### PR TITLE
Updated .gitignore added logs directory and fixed logging path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Custom
+*.log

--- a/enum_dns.py
+++ b/enum_dns.py
@@ -5,7 +5,7 @@ import os
 import sys
 import time
 
-OUTFILE = os.path.abspath("/tmp/dns_{0}.log".format(time.strftime("%d-%b-%Y", time.gmtime())))
+OUTFILE = os.path.abspath("{0}/logs/dns_{1}.log".format(os.path.dirname(os.path.realpath(__file__)), time.strftime("%d-%b-%Y", time.gmtime())))
 
 
 def init(logfile):


### PR DESCRIPTION
1. Added logs directory for log storage.
2. Updated .gitignore file to ignore an *.log files.
3. Fixed relative logging path to use the local `/logs` directory instead of hard coded `/tmp/` directory.